### PR TITLE
Add test to ensure registrations persist

### DIFF
--- a/stubs/default/tests/Feature/RegistrationTest.php
+++ b/stubs/default/tests/Feature/RegistrationTest.php
@@ -29,4 +29,33 @@ class RegistrationTest extends TestCase
         $this->assertAuthenticated();
         $response->assertRedirect(RouteServiceProvider::HOME);
     }
+    
+    public function test_users_can_register_and_then_login()
+    {
+        $userEmail = "test@example.com";
+
+        // Register new user
+        $response = $this->post('/register', [
+            'name' => 'Test User',
+            'email' => $userEmail,
+            'password' => 'password',
+            'password_confirmation' => 'password',
+        ]);
+
+        $this->assertAuthenticated();
+        $response->assertRedirect(RouteServiceProvider::HOME);
+
+        // Now logout
+        $this->app['auth']->logout();
+        $this->assertGuest();
+
+        // Now login using new user credentials
+        $response = $this->post('/login', [
+            'email' => $userEmail,
+            'password' => 'password',
+        ]);
+
+        $this->assertAuthenticated();
+        $response->assertRedirect(RouteServiceProvider::HOME);
+    }
 }


### PR DESCRIPTION
Simple test to ensure that new user registrations are persisted correctly in the database. Without this test a default Breeze app only tests to ensure a user is authenticated after logging in, and able to authenticate with already stored credentials. There is no test to ensure that a user's details are being persisted correctly during registration.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
